### PR TITLE
Pass frame to `cnfonts-set-font-with-saved-step`

### DIFF
--- a/cnfonts.el
+++ b/cnfonts.el
@@ -1198,12 +1198,12 @@ FONTSIZES-LIST."
     (when choose
       (insert (format "\"%s\"" choose)))))
 
-(defun cnfonts-set-font-first-time (&rest _args)
+(defun cnfonts-set-font-first-time (&optional frame)
   "Emacs 启动后，第一次设置字体使用的函数.
 
 这个函数会使用 cnfonts 缓存机制，设置字体速度较快。"
   (let ((cnfonts-use-cache t))
-    (cnfonts-set-font-with-saved-step)))
+    (cnfonts-set-font-with-saved-step frame)))
 
 ;;;###autoload
 (defun cnfonts-enable ()


### PR DESCRIPTION
`cnfonts--set-font` 使用 `(selected-frame)` 得到需要配置的 frame 。而当运行
`after-make-frame-functions` 时，`(selected-frame)` 并非新的 frame ，而是旧的。
需要明确地将 frame 传入 `cnfonts-set-font-with-saved-step` 。

Fix #94