### PR TITLE
Support SFMono Nerd Font

### DIFF
--- a/cnfonts.el
+++ b/cnfonts.el
@@ -499,7 +499,7 @@ cnfont 的设置都保存在文件中，在默认情况下，每次读取 profil
      "Monoid" "Edlo" "Iosevka" "Mononoki" "Robot Mono" "Fantasque" "Fira Code" "Go Mono"
      "Noto Sans Mono CJK" "InputMonoCompressed" "Hasklig" "Terminus" "FantasqueSansMono"
      "AnonymousPro" "3270" "Arimo" "D2Coding" "Inconsolata-g" "ProFont for Powerline"
-     "Meslo" "Meslo Dotted" "Noto Mono" "Symbol Neu" "Tinos" "Space Mono")
+     "Meslo" "Meslo Dotted" "Noto Mono" "Symbol Neu" "Tinos" "Space Mono" "SFMono Nerd Font")
     ("微软雅黑" "Noto Sans S Chinese Regular" "Microsoft Yahei" "Microsoft_Yahei" "Ubuntu Mono"
      "文泉驿等宽微米黑" "文泉驿等宽正黑" "黑体" "Source Han Sans SC"  "Source Han Serif SC"
      "思源黑体 CN Regular" "思源黑体 CN Medium" "思源黑体 CN Normal" "思源宋体 CN"


### PR DESCRIPTION
The SFMono font is come together with Macos, 

This patch supports the nerd variant of this font, 

which is offered on the below URL: https://github.com/2players/sfmono-nerd-font