### PR TITLE
修复 Emacs 以 daemon 模式启动时 cnfonts 不生效的问题

### DIFF
--- a/cnfonts.el
+++ b/cnfonts.el
@@ -878,7 +878,7 @@ When PROFILE-NAME is non-nil, save to this profile instead."
   "cnfonts mode."
   :global t
   (cond
-   ((and (display-graphic-p) cnfonts-mode)
+   (cnfonts-mode
     (add-hook 'after-make-frame-functions #'cnfonts-set-font)
     (add-hook 'window-setup-hook #'cnfonts-set-font)
     (message "[cnfonts]: cnfonts-mode 激活，使用 `cnfonts-edit-profile' 命令调整字体设置。"))

--- a/cnfonts.el
+++ b/cnfonts.el
@@ -786,7 +786,7 @@ When PROFILE-NAME is non-nil, save to this profile instead."
   (let* ((profile-name (cnfonts--get-current-profile t))
          (profile-fontsize (cnfonts--get-profile-fontsize profile-name))
          (fontsizes-list (cnfonts--get-fontsizes profile-fontsize)))
-    (when (display-graphic-p)
+    (when (display-graphic-p frame)
       (if frame
           (with-selected-frame frame
             (cnfonts--set-font fontsizes-list))


### PR DESCRIPTION
最近我更新 cnfonts 后发现 Emacs daemon 不能设置字体，请合并 PR 以修复。问题原因和分析请查看提交日志。谢谢