### PR TITLE
Fix Unicode display issue.

### DIFF
--- a/cnfonts.el
+++ b/cnfonts.el
@@ -567,7 +567,7 @@ file's name."
     ;; 设置中文字体，注意，不要使用 'unicode charset,
     ;; 否则上面的英文字体设置将会失效。
     (when (cnfonts--fontspec-valid-p chinese-fontspec)
-      (dolist (charset '(kana han cjk-misc bopomofo gb18030))
+      (dolist (charset '(kana han cjk-misc bopomofo))
         (set-fontset-font
          "fontset-default"
          charset chinese-fontspec)))


### PR DESCRIPTION
Fix #151 (unicode display issue).

The code used to apply CJK font to 'kana han cjk-misc bopomofo gb18030. While the first few are a script symbol, the last one is a charset symbol. (see help-function set-fontset-font in emacs). gb18030 is a Unicode Transformation Format, which encodes all unicodes. All other Unicode characters are displayed using this font. This is certainly not the purpose of adding gb18030 here. Removing gb18030 would make unicode emoji (and other unicode characters) correctly displayed again.