### PR TITLE
Set `chinese-fontspec` for hangul

### DIFF
--- a/cnfonts.el
+++ b/cnfonts.el
@@ -567,7 +567,7 @@ file's name."
     ;; 设置中文字体，注意，不要使用 'unicode charset,
     ;; 否则上面的英文字体设置将会失效。
     (when (cnfonts--fontspec-valid-p chinese-fontspec)
-      (dolist (charset '(kana han cjk-misc bopomofo))
+      (dolist (charset '(kana han cjk-misc bopomofo hangul))
         (set-fontset-font
          "fontset-default"
          charset chinese-fontspec)))


### PR DESCRIPTION
Check the code from the previous revision [e821e6d]:

```elisp
    ;; 设置中文字体，注意，不要使用 'unicode charset,
    ;; 否则上面的英文字体设置将会失效。
    (when (cnfonts--fontspec-valid-p chinese-fontspec)
      (dolist (charset '(kana han cjk-misc bopomofo hangul))
        (set-fontset-font
         "fontset-default"
         charset chinese-fontspec)))

    ;; 当所选的 chinese-fontspec 不支持韩语(hangul)时, 用
    ;; extb-fontspec 来显示
    (when (cnfonts--fontspec-valid-p extb-fontspec)
      (set-fontset-font
       "fontset-default"
       'hangul extb-fontspec nil 'append))
```

According to the second comment, `chinese-fontspec` should be set to overwrite previous settings to display hangul, but it was not.

This patch fixes this issue.

[e821e6d]: https://github.com/tumashu/cnfonts/blob/e821e6d28367e120ad2f9b92b02d914b5f387e8d/cnfonts.el#L567-L580