### PR TITLE
增加鼠标和触屏绑定，以解决鼠标触屏放大缩小字体时中英文大小不一致

### DIFF
--- a/cnfonts.el
+++ b/cnfonts.el
@@ -695,6 +695,7 @@ When PROFILE-NAME is non-nil, save to this profile instead."
   (interactive)
   (cnfonts--next-fontsize 1))
 
+;;;###autoload
 (defun cnfonts--next-fontsize (n)
   "使用下 N 个字号."
   (if (not (display-graphic-p))

--- a/cnfonts.el
+++ b/cnfonts.el
@@ -98,8 +98,16 @@ It record the current profile and profile fontsize."
   "A hook, by which user can set additional fonts."
   :type 'hook)
 
-(defvar cnfonts-mode-map (make-sparse-keymap)
-  "Keymap for `cnfonts-mode'.")
+(defvar cnfonts-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-<mouse-5>") #'cnfonts-mouse-wheel-text-scale)
+    (define-key map (kbd "C-<mouse-4>") #'cnfonts-mouse-wheel-text-scale)
+    (define-key map (kbd "C-<wheel-down>") #'cnfonts-mouse-wheel-text-scale)
+    (define-key map (kbd "C-<wheel-up>") #'cnfonts-mouse-wheel-text-scale)
+    (define-key map (kbd "<touchscreen-pinch>") #'cnfonts-touch-screen-pinch)
+    map)
+  "Keymap used by `cnfonts-mode'.")
+
 
 (defvar cnfonts--config-info nil
   "The cofonts config info read from config file.")
@@ -719,6 +727,95 @@ When PROFILE-NAME is non-nil, save to this profile instead."
   "使用 `cnfonts-default-fontsize' 重置字号."
   (interactive)
   (cnfonts--next-fontsize 0))
+
+
+
+(defun cnfonts-mouse-wheel-text-scale (event)
+  "修改emacs原本代码，把改变字体大小的部分换成cnfonts的，原来的可以参见 `text-scale-adjust'."
+  (interactive (list last-input-event))
+  (let ((selected-window (selected-window))
+        (scroll-window (mouse-wheel--get-scroll-window event))
+        (button (mwheel-event-button event)))
+    (select-window scroll-window 'mark-for-redisplay)
+    (unwind-protect
+        (cond ((memq button (list mouse-wheel-down-event
+                                  mouse-wheel-down-alternate-event))
+	       (cnfonts-increase-fontsize)
+	       ;;替换成cnfonts
+	       ;;(text-scale-increase 1)
+	       )
+	      ((memq button (list mouse-wheel-up-event
+                                  mouse-wheel-up-alternate-event))
+	       ;;(text-scale-decrease 1)
+	       ;;替换成cnfonts
+	       (cnfonts-decrease-fontsize)
+	       ))
+      (select-window selected-window))))
+
+;;;###autoload
+(defun cnfonts-touch-screen-pinch (event)
+  "修改emacs原本代码，把改变字体大小的部分换成cnfonts的"
+  (interactive "e")
+  (require 'face-remap)
+  (let* ((posn (cadr event))
+         (window (posn-window posn))
+         (scale (nth 2 event))
+         (ratio-diff (nth 5 event))
+         current-scale start-scale)
+    (when (windowp window)
+      (with-selected-window window
+        (setq current-scale (if text-scale-mode
+                                text-scale-mode-amount
+			      0)
+	      start-scale (or (aref touch-screen-aux-tool 7)
+			      (aset touch-screen-aux-tool 7
+				    current-scale)))
+        ;; Set the text scale.
+	;;这里就是设置字体缩放的地方
+        ;;(text-scale-set (+ start-scale
+        ;;                   (round (log scale text-scale-mode-step))))
+        (if (> (round (log scale text-scale-mode-step )) 0)
+	    (cnfonts-increase-fontsize)
+	  (cnfonts-decrease-fontsize)
+	  )
+        ;; Subsequently move the row which was at the centrum to its Y
+        ;; position.
+        (if (and (not (eq current-scale
+                          text-scale-mode-amount))
+                 (posn-point posn)
+                 (cdr (posn-x-y posn)))
+	    (touch-screen-scroll-point-to-y (posn-point posn)
+					    (cdr (posn-x-y posn)))
+          ;; Rather than scroll POSN's point to its old row, scroll the
+          ;; display by the Y axis deltas within EVENT.
+          (let ((height (window-default-line-height))
+                (y-accumulator (or (aref touch-screen-aux-tool 8) 0)))
+	    (setq y-accumulator (+ y-accumulator (nth 4 event)))
+	    (when (or (> y-accumulator height)
+		      (< y-accumulator (- height)))
+	      (ignore-errors
+                (if (> y-accumulator 0)
+		    (scroll-down 1)
+                  (scroll-up 1)))
+	      (setq y-accumulator 0))
+	    (aset touch-screen-aux-tool 8 y-accumulator))
+          ;; Likewise for the X axis deltas.
+          (let ((width (frame-char-width))
+                (x-accumulator (or (aref touch-screen-aux-tool 9) 0)))
+	    (setq x-accumulator (+ x-accumulator (nth 3 event)))
+	    (when (or (> x-accumulator width)
+		      (< x-accumulator (- width)))
+	      ;; Do not hscroll if the ratio has shrunk, for that is
+	      ;; generally attended by the centerpoint moving left,
+	      ;; and Emacs can hscroll left even when no lines are
+	      ;; truncated.
+	      (unless (and (< x-accumulator 0)
+                           (< ratio-diff 0))
+                (if (> x-accumulator 0)
+		    (scroll-right 1)
+                  (scroll-left 1)))
+	      (setq x-accumulator 0))
+            (aset touch-screen-aux-tool 9 x-accumulator)))))))
 
 ;;;###autoload
 (defun cnfonts-switch-profile ()


### PR DESCRIPTION
在桌面GUI和安卓native上都有效